### PR TITLE
Bump version number.

### DIFF
--- a/pedant/__init__.py
+++ b/pedant/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '1.0.0'  # pragma no cover
+__version__ = '1.0.1'  # pragma no cover


### PR DESCRIPTION
@lucaswiman 

I botched the upload to PyPI by accidentally uploading the `django-pedant-1.0.0.tar.gz` tarball to the 0.0.5 release using the web UI. Even after I removed the file, I'm not able to reupload (the exact same file) to the 1.0.0 release. This appears to be intentional: https://github.com/pypa/packaging-problems/issues/74

Bumping the version number so that I can attempt to upload the library again, but this time, using the command line tools.
