### PR TITLE
Update one more reference to log_on_template_errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To simply *log* if there are template failures, you can use the `log_template_er
 ```python
 import logging
 
-from pedant.decorators import log_on_template_errors
+from pedant.decorators import log_template_errors
 
 logger = logging.getLogger('myapp.views')
 


### PR DESCRIPTION
One more part of #3, #4 missed one reference to `log_on_template_errors`, which doesn't exist.
